### PR TITLE
Add new command to inspect the Raft meta store and configuration files

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -210,10 +210,6 @@
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-math3</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>io.camunda</groupId>
-                    <artifactId>zeebe-atomix-utils</artifactId>
-                </exclusion>
                 <!--                    <exclusion>-->
                 <!--                        <groupId>com.google.guava</groupId>-->
                 <!--                        <artifactId>guava</artifactId>-->

--- a/backend/src/main/kotlin/io/zell/zdb/log/LogContentReader.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/LogContentReader.kt
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.impl.record.RecordMetadata
 import io.camunda.zeebe.protocol.record.RecordType
 import io.zell.zdb.log.records.*
 import io.zell.zdb.log.records.old.RecordMetadataBefore83
+import io.zell.zdb.raft.RaftLogReader
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import org.agrona.concurrent.UnsafeBuffer

--- a/backend/src/main/kotlin/io/zell/zdb/log/LogFactory.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/LogFactory.kt
@@ -16,6 +16,8 @@
 package io.zell.zdb.log
 
 import io.zell.zdb.journal.file.SegmentedReadOnlyJournal
+import io.zell.zdb.raft.RaftLogReader
+import io.zell.zdb.raft.RaftLogUncommittedReader
 import java.nio.file.Path
 
 class LogFactory {

--- a/backend/src/main/kotlin/io/zell/zdb/log/LogStatus.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/log/LogStatus.kt
@@ -15,6 +15,7 @@
  */
 package io.zell.zdb.log
 
+import io.zell.zdb.raft.RaftLogReader
 import java.nio.file.Path
 
 

--- a/backend/src/main/kotlin/io/zell/zdb/raft/MetaStoreReader.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/raft/MetaStoreReader.kt
@@ -1,0 +1,43 @@
+package io.zell.zdb.raft
+
+import io.atomix.raft.storage.serializer.MetaStoreSerializer
+import io.atomix.raft.storage.system.Configuration
+import io.atomix.raft.storage.system.MetaStoreRecord
+import java.io.IOException
+import java.io.UncheckedIOException
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
+class MetaStoreReader @JvmOverloads constructor(
+    private val metaPath: Path,
+    private val configPath: Path,
+    private val serializer: MetaStoreSerializer = MetaStoreSerializer()
+) {
+    fun readConfig(): Configuration {
+        try {
+            val bytes = Files.readAllBytes(configPath)
+            val buffer = ByteBuffer.wrap(bytes)
+            return serializer.readConfiguration(buffer)
+        } catch (e: IOException) {
+            throw UncheckedIOException("Failed to read configuration from $configPath", e)
+        }
+    }
+
+    fun readMetaStore(): MetaStoreRecord {
+        try {
+            FileChannel.open(metaPath, StandardOpenOption.READ).use { channel ->
+                var count: Int
+                do {
+                    count = channel.read(serializer.metaByteBuffer())
+                } while (count > 0)
+            }
+        } catch (e: IOException) {
+            throw UncheckedIOException("Failed to read meta store record from $metaPath", e)
+        }
+
+        return serializer.readRecord()
+    }
+}

--- a/backend/src/main/kotlin/io/zell/zdb/raft/RaftLogReader.java
+++ b/backend/src/main/kotlin/io/zell/zdb/raft/RaftLogReader.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zell.zdb.log;
+package io.zell.zdb.raft;
 
 
 import io.zell.zdb.log.records.IndexedRaftLogEntryImpl;

--- a/backend/src/main/kotlin/io/zell/zdb/raft/RaftLogUncommittedReader.java
+++ b/backend/src/main/kotlin/io/zell/zdb/raft/RaftLogUncommittedReader.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zell.zdb.log;
+package io.zell.zdb.raft;
 
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.serializer.RaftEntrySBESerializer;

--- a/backend/src/main/kotlin/io/zell/zdb/raft/RaftStatus.kt
+++ b/backend/src/main/kotlin/io/zell/zdb/raft/RaftStatus.kt
@@ -1,0 +1,93 @@
+package io.zell.zdb.raft
+
+import io.atomix.raft.cluster.RaftMember
+import io.atomix.raft.storage.system.Configuration
+import io.atomix.raft.storage.system.MetaStoreRecord
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.nio.file.Path
+
+class RaftStatus(partitionPath: Path) {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val reader: MetaStoreReader
+
+    init {
+        val partitionId = partitionPath.fileName.toString()
+        val metaPath = partitionPath.resolve("raft-partition-partition-$partitionId.meta")
+        val configPath =
+            partitionPath.resolve("raft-partition-partition-$partitionId.conf")
+
+        reader = MetaStoreReader(metaPath, configPath)
+    }
+
+    fun details(): RaftStatusDetails {
+        return RaftStatusDetails(reader.readMetaStore(), reader.readConfig())
+    }
+
+    fun detailsAsJson(): String {
+        return json.encodeToString(details());
+    }
+
+    @JvmRecord
+    @Serializable
+    data class RaftStatusDetails(val meta: MetaStoreDetails, val config: RaftConfigDetails) {
+        constructor(metaStoreRecord: MetaStoreRecord, configuration: Configuration) : this(
+            MetaStoreDetails(metaStoreRecord),
+            RaftConfigDetails(configuration)
+        )
+    }
+
+    @JvmRecord
+    @Serializable
+    data class MetaStoreDetails(
+        val term: Long,
+        val lastFlushedIndex: Long,
+        val commitIndex: Long,
+        val votedFor: String
+    ) {
+        constructor(metaStoreRecord: MetaStoreRecord) : this(
+            metaStoreRecord.term,
+            metaStoreRecord.lastFlushedIndex,
+            metaStoreRecord.commitIndex,
+            metaStoreRecord.votedFor ?: ""
+        )
+    }
+
+    @JvmRecord
+    @Serializable
+    data class RaftConfigDetails(
+        val index: Long,
+        val term: Long,
+        val time: Long,
+        val force: Boolean,
+        val requiresJointConsensus: Boolean,
+        val newMembers: Collection<RaftMemberDetails>,
+        val oldMembers: Collection<RaftMemberDetails>
+    ) {
+        constructor(configuration: Configuration) : this(
+            configuration.index,
+            configuration.term,
+            configuration.time,
+            configuration.force,
+            configuration.requiresJointConsensus(),
+            configuration.newMembers.map { RaftMemberDetails(it) },
+            configuration.oldMembers.map { RaftMemberDetails(it) }
+        )
+    }
+
+    @JvmRecord
+    @Serializable
+    data class RaftMemberDetails(
+        val id: String,
+        val hash: Int,
+        val type: String,
+        val lastUpdated: String
+    ) {
+        constructor(member: RaftMember) : this(
+            member.memberId().id(),
+            member.hash(),
+            member.type.name,
+            member.lastUpdated.toString()
+        )
+    }
+}

--- a/cli/src/main/java/io/zell/zdb/ZeebeDebugger.java
+++ b/cli/src/main/java/io/zell/zdb/ZeebeDebugger.java
@@ -17,6 +17,7 @@ package io.zell.zdb;
 
 import io.zell.zdb.ZeebeDebugger.VersionProvider;
 import io.zell.zdb.journal.LogCommand;
+import io.zell.zdb.journal.RaftCommand;
 import io.zell.zdb.state.InstanceCommand;
 import io.zell.zdb.state.ProcessCommand;
 import io.zell.zdb.state.StateCommand;
@@ -38,6 +39,7 @@ import picocli.CommandLine.RunLast;
       InstanceCommand.class,
       IncidentCommand.class,
       LogCommand.class,
+      RaftCommand.class,
       StateCommand.class
     })
 public class ZeebeDebugger implements Callable<Integer> {

--- a/cli/src/main/java/io/zell/zdb/journal/RaftCommand.java
+++ b/cli/src/main/java/io/zell/zdb/journal/RaftCommand.java
@@ -1,0 +1,4 @@
+package io.zell.zdb.journal;
+
+public class RaftCommand {
+}

--- a/cli/src/main/java/io/zell/zdb/journal/RaftCommand.java
+++ b/cli/src/main/java/io/zell/zdb/journal/RaftCommand.java
@@ -1,4 +1,114 @@
 package io.zell.zdb.journal;
 
-public class RaftCommand {
+import io.atomix.raft.cluster.RaftMember;
+import io.zell.zdb.raft.RaftStatus;
+import org.jetbrains.annotations.NotNull;
+import picocli.CommandLine;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+@SuppressWarnings("unused")
+@CommandLine.Command(
+    name = "raft",
+    mixinStandardHelpOptions = true,
+    description = "Allows to inspect the log via sub commands")
+public class RaftCommand implements Callable<Integer> {
+  @CommandLine.Spec private CommandLine.Model.CommandSpec spec;
+
+  public enum Format {
+    JSON,
+    TABLE,
+  }
+
+  @CommandLine.Option(
+      names = {"-p", "--path"},
+      paramLabel = "LOG_PATH",
+      description = "The path to the partition log data, should end with the partition id.",
+      required = true,
+      scope = CommandLine.ScopeType.INHERIT)
+  private Path partitionPath;
+
+  @CommandLine.Option(
+      names = {"-f", "--format"},
+      description =
+          "Print's the complete log in the specified format, defaults to json. Possible values: [ ${COMPLETION-CANDIDATES} ]",
+      defaultValue = "JSON",
+      scope = CommandLine.ScopeType.INHERIT)
+  private Format format;
+
+  @CommandLine.Command(name = "status", description = "Print's the status of the Raft server")
+  public int status() {
+    if (format == Format.JSON) {
+      System.out.println(new RaftStatus(partitionPath).detailsAsJson());
+    } else {
+      printDetailsAsTable();
+    }
+    return 0;
+  }
+
+  private void printDetailsAsTable() {
+    final var status = new RaftStatus(partitionPath).details();
+    System.out.printf(
+        """
+            --------------------------------------------------------------
+            Raft Status for partition '%s':
+            --------------------------------------------------------------
+            Meta Store:
+                Term:                    %d
+                Last Flushed Index:      %d
+                Commit Index:            %d
+                Voted For:               %s%n""",
+        partitionPath.getFileName(),
+        status.meta().term(),
+        status.meta().lastFlushedIndex(),
+        status.meta().commitIndex(),
+        status.meta().votedFor());
+    System.out.printf(
+        """
+            --------------------------------------------------------------
+            Configuration:
+                Index:                   %d
+                Term:                    %d
+                Time:                    %d
+                Force:                   %b
+                Requires Join Consensus: %b
+                New Members:             %s
+                Old Members:             %s
+            --------------------------------------------------------------""",
+        status.config().index(),
+        status.config().term(),
+        status.config().time(),
+        status.config().force(),
+        status.config().requiresJointConsensus(),
+        formatMembers(status.config().newMembers()),
+        formatMembers(status.config().oldMembers()));
+  }
+
+  @NotNull
+  private static String formatMembers(Collection<RaftStatus.RaftMemberDetails> members) {
+    if (members.isEmpty()) {
+      return "[]";
+    }
+
+    return "["
+        + System.lineSeparator()
+        + members.stream()
+            .map(
+                m ->
+                    """
+            \t\tId: %s, Type: %s, Hash: %d, Updated: %s"""
+                        .formatted(m.id(), m.type(), m.hash(), m.lastUpdated()))
+            .collect(Collectors.joining(System.lineSeparator()))
+        + System.lineSeparator()
+        + "    ]";
+  }
+
+  @Override
+  public Integer call() {
+    spec.commandLine().usage(System.out);
+    return 0;
+  }
 }


### PR DESCRIPTION
This PR adds a new command to inspect the Raft meta store and configuration files.

The command is used as `zdb raft status -p=PARTITION_PATH -f=FORMAT`, where `FORMAT` is one of `JSON` or `TABLE`, and the path is the usual partition path (e.g. `/usr/local/zeebe/data/raft-partition/partitions/1`.