### PR TITLE
refactor: share snapshot generator support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,17 +35,22 @@ When a ZDB behavior change causes golden tests to fail and the new output is cor
 # Regenerate all golden files for v8.8
 mvn test -pl backend -DskipTests=false -DupdateGoldens=true -Dtest=Version88GoldenTest
 
+# To regenerate all versions at once:
+mvn test -pl backend -DskipTests=false -DupdateGoldens=true \
+  '-Dtest=Version81GoldenTest,Version82GoldenTest,Version83GoldenTest,Version84GoldenTest,Version85GoldenTest,Version86GoldenTest,Version87GoldenTest,Version88GoldenTest'
+
 # Review what changed
-git diff backend/src/test/resources/golden/v8.8/
+git diff backend/src/test/resources/golden/
 
 # Commit if the diff looks right
-git add backend/src/test/resources/golden/v8.8/ && git commit -m "test: update v8.8 golden files"
+git add backend/src/test/resources/golden/ && git commit -m "test: update golden files"
 ```
 
-**Regenerating the snapshot (rare — only needed when Zeebe changes its on-disk format):**
+**Regenerating a snapshot (rare - only needed when Zeebe changes its on-disk format):**
 
 ```bash
-mvn test -pl backend -DskipTests=false -Dgroups=snapshot-generator -Dtest=SnapshotGeneratorV88Test
+# Override the default surefire.excludedGroups to un-exclude snapshot-generator tests
+mvn test -pl backend -DskipTests=false '-Dsurefire.excludedGroups=' -Dtest=SnapshotGeneratorV88Test
 git add backend/src/test/resources/zeebe-states/v8.8.zip && git commit -m "test: regenerate v8.8 snapshot"
 # Then regenerate golden files as above
 ```
@@ -53,7 +58,7 @@ git add backend/src/test/resources/zeebe-states/v8.8.zip && git commit -m "test:
 **Adding a new Zeebe version:**
 
 1. Copy `SnapshotGeneratorV88Test` to `SnapshotGeneratorV89Test`, update the Docker image tag
-2. Run the generator: `mvn test -pl backend -DskipTests=false -Dgroups=snapshot-generator -Dtest=SnapshotGeneratorV89Test`
+2. Run the generator: `mvn test -pl backend -DskipTests=false '-Dsurefire.excludedGroups=' -Dtest=SnapshotGeneratorV89Test`
 3. Copy `Version88GoldenTest` to `Version89GoldenTest`, update paths to `v8.9`
 4. Seed golden files: `mvn test -pl backend -DskipTests=false -DupdateGoldens=true -Dtest=Version89GoldenTest`
 5. Commit the new snapshot and golden files

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -30,6 +30,10 @@
     <packaging>jar</packaging>
     <name>ZDB Backend</name>
 
+    <properties>
+        <surefire.excludedGroups>snapshot-generator</surefire.excludedGroups>
+    </properties>
+
     <build>
         <sourceDirectory>src/main/kotlin</sourceDirectory>
         <testSourceDirectory>src/test/kotlin</testSourceDirectory>
@@ -82,8 +86,9 @@
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <!-- snapshot-generator requires Docker and rewrites committed resources; run manually only -->
-                    <excludedGroups>snapshot-generator</excludedGroups>
+                    <!-- snapshot-generator requires Docker and rewrites committed resources; run manually only.
+                         Override on the command line with -Dsurefire.excludedGroups= to run generators. -->
+                    <excludedGroups>${surefire.excludedGroups}</excludedGroups>
                 </configuration>
             </plugin>
         </plugins>

--- a/backend/src/test/kotlin/io/zell/zdb/SnapshotGeneratorSupport.java
+++ b/backend/src/test/kotlin/io/zell/zdb/SnapshotGeneratorSupport.java
@@ -33,21 +33,6 @@ public final class SnapshotGeneratorSupport {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final Path SNAPSHOT_ROOT = Path.of("src/test/resources/zeebe-states");
 
-  private static final BpmnModelInstance PROCESS =
-      Bpmn.createExecutableProcess("process")
-          .startEvent()
-          .parallelGateway("gw")
-          .serviceTask("task")
-          .zeebeJobType("type")
-          .endEvent()
-          .moveToLastGateway()
-          .serviceTask("incidentTask")
-          .zeebeInputExpression("=foo", "bar")
-          .zeebeJobType("incidentTask")
-          .zeebeJobRetriesExpression("=foo")
-          .endEvent()
-          .done();
-
   private SnapshotGeneratorSupport() {}
 
   @FunctionalInterface
@@ -63,6 +48,17 @@ public final class SnapshotGeneratorSupport {
       final String dockerImage,
       final ContainerFactory containerFactory,
       final Logger logger) {
+    return startContainerAndCreateContent(
+        testClass, dockerImage, "incidentTask", true, containerFactory, logger);
+  }
+
+  public static GeneratorContext startContainerAndCreateContent(
+      final Class<?> testClass,
+      final String dockerImage,
+      final String incidentJobType,
+      final boolean includeRetriesExpression,
+      final ContainerFactory containerFactory,
+      final Logger logger) {
     final Path tempDir = TestUtils.newTmpFolder(testClass).toPath();
     try {
       Files.createDirectories(tempDir);
@@ -70,13 +66,46 @@ public final class SnapshotGeneratorSupport {
       throw new RuntimeException(e);
     }
 
-    final var zeebeContentCreator = new ZeebeContentCreator(PROCESS);
+    final var zeebeContentCreator =
+        new ZeebeContentCreator(createProcess(incidentJobType, includeRetriesExpression));
     final var zeebeContainer =
         containerFactory.create(DockerImageName.parse(dockerImage), tempDir.toString(), logger);
     zeebeContainer.start();
     zeebeContentCreator.createContent(zeebeContainer.getExternalGatewayAddress());
 
     return new GeneratorContext(tempDir, zeebeContainer, zeebeContentCreator);
+  }
+
+  private static BpmnModelInstance createProcess(
+      final String incidentJobType, final boolean includeRetriesExpression) {
+    if (includeRetriesExpression) {
+      return Bpmn.createExecutableProcess("process")
+          .startEvent()
+          .parallelGateway("gw")
+          .serviceTask("task")
+          .zeebeJobType("type")
+          .endEvent()
+          .moveToLastGateway()
+          .serviceTask("incidentTask")
+          .zeebeInputExpression("=foo", "bar")
+          .zeebeJobType(incidentJobType)
+          .zeebeJobRetriesExpression("=foo")
+          .endEvent()
+          .done();
+    }
+
+    return Bpmn.createExecutableProcess("process")
+        .startEvent()
+        .parallelGateway("gw")
+        .serviceTask("task")
+        .zeebeJobType("type")
+        .endEvent()
+        .moveToLastGateway()
+        .serviceTask("incidentTask")
+        .zeebeInputExpression("=foo", "bar")
+        .zeebeJobType(incidentJobType)
+        .endEvent()
+        .done();
   }
 
   public static void stopContainerAndCleanup(final GeneratorContext context) throws IOException {

--- a/backend/src/test/kotlin/io/zell/zdb/SnapshotGeneratorSupport.java
+++ b/backend/src/test/kotlin/io/zell/zdb/SnapshotGeneratorSupport.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2021 Christopher Kujawa (zelldon91@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zell.zdb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.containers.ZeebeContainer;
+import io.zell.zdb.state.incident.IncidentState;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import org.assertj.core.api.Assertions;
+import org.slf4j.Logger;
+import org.testcontainers.utility.DockerImageName;
+
+public final class SnapshotGeneratorSupport {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final Path SNAPSHOT_ROOT = Path.of("src/test/resources/zeebe-states");
+
+  private static final BpmnModelInstance PROCESS =
+      Bpmn.createExecutableProcess("process")
+          .startEvent()
+          .parallelGateway("gw")
+          .serviceTask("task")
+          .zeebeJobType("type")
+          .endEvent()
+          .moveToLastGateway()
+          .serviceTask("incidentTask")
+          .zeebeInputExpression("=foo", "bar")
+          .zeebeJobType("incidentTask")
+          .zeebeJobRetriesExpression("=foo")
+          .endEvent()
+          .done();
+
+  private SnapshotGeneratorSupport() {}
+
+  @FunctionalInterface
+  public interface ContainerFactory {
+    ZeebeContainer create(DockerImageName dockerImage, String tempDir, Logger logger);
+  }
+
+  public record GeneratorContext(
+      Path tempDir, ZeebeContainer zeebeContainer, ZeebeContentCreator zeebeContentCreator) {}
+
+  public static GeneratorContext startContainerAndCreateContent(
+      final Class<?> testClass,
+      final String dockerImage,
+      final ContainerFactory containerFactory,
+      final Logger logger) {
+    final Path tempDir = TestUtils.newTmpFolder(testClass).toPath();
+    try {
+      Files.createDirectories(tempDir);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    final var zeebeContentCreator = new ZeebeContentCreator(PROCESS);
+    final var zeebeContainer =
+        containerFactory.create(DockerImageName.parse(dockerImage), tempDir.toString(), logger);
+    zeebeContainer.start();
+    zeebeContentCreator.createContent(zeebeContainer.getExternalGatewayAddress());
+
+    return new GeneratorContext(tempDir, zeebeContainer, zeebeContentCreator);
+  }
+
+  public static void stopContainerAndCleanup(final GeneratorContext context) throws IOException {
+    if (context != null) {
+      final var zeebeContainer = context.zeebeContainer();
+      if (zeebeContainer != null && zeebeContainer.isRunning()) {
+        zeebeContainer.stop();
+      }
+      SnapshotFixture.deleteRecursively(context.tempDir());
+    }
+  }
+
+  public static void generateSnapshot(final GeneratorContext context, final String version)
+      throws IOException {
+    context.zeebeContainer().stop();
+
+    final Path snapshotTarget = SNAPSHOT_ROOT.resolve(version);
+    final Path snapshotZip = SNAPSHOT_ROOT.resolve(version + ".zip");
+
+    SnapshotFixture.deleteRecursively(snapshotTarget);
+    SnapshotFixture.copyDirectory(context.tempDir(), snapshotTarget);
+
+    final var runtimePath = ZeebePaths.Companion.getRuntimePath(snapshotTarget.toFile(), "1");
+    final var incidentKeys = new ArrayList<Long>();
+    new IncidentState(runtimePath)
+        .listIncidents(
+            json -> {
+              try {
+                incidentKeys.add(OBJECT_MAPPER.readTree(json).get("key").asLong());
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
+    Assertions.assertThat(incidentKeys)
+        .as("expected exactly one incident in the snapshot")
+        .hasSize(1);
+
+    final var zeebeContentCreator = context.zeebeContentCreator();
+    final var metadata =
+        new SnapshotMetadata(
+            zeebeContentCreator.firstProcessKey,
+            zeebeContentCreator.secondProcessKey,
+            zeebeContentCreator.processInstanceEvent.getProcessInstanceKey(),
+            zeebeContentCreator.elementInstanceKey,
+            zeebeContentCreator.responseJobKey,
+            incidentKeys.get(0));
+
+    OBJECT_MAPPER
+        .writerWithDefaultPrettyPrinter()
+        .writeValue(snapshotTarget.resolve("metadata.json").toFile(), metadata);
+
+    SnapshotFixture.pack(snapshotTarget, snapshotZip);
+    SnapshotFixture.deleteRecursively(snapshotTarget);
+  }
+}

--- a/backend/src/test/kotlin/io/zell/zdb/TestUtils.java
+++ b/backend/src/test/kotlin/io/zell/zdb/TestUtils.java
@@ -107,6 +107,9 @@ public final class TestUtils {
             // with 8.2 we disabled WAL per default
             // we have to enabled it inorder to access the data from RocksDB
             .withEnv("ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_DISABLEWAL", "false")
+            // Use loopback as the advertised host so Zeebe's internal cluster messaging can always
+            // resolve itself, regardless of how Testcontainers sets the container hostname.
+            .withEnv("ZEEBE_BROKER_NETWORK_ADVERTISEDHOST", "127.0.0.1")
             .withLogConsumer(new Slf4jLogConsumer(logger))
             .withFileSystemBind(tempDir, CONTAINER_PATH, BindMode.READ_WRITE);
 
@@ -118,6 +121,37 @@ public final class TestUtils {
             ZeebePort.MONITORING.getPort()));
 
     return container;
+  }
+
+  /**
+   * Creates a ZeebeContainer with the given docker image name. The container will mount the given
+   * tempDir to /usr/local/zeebe/data in order to access the RocksDB data.
+   *
+   * <p>The container will be started with the current user (see {@link #getRunAsUser()}) in order
+   * to access the data and delete it later.
+   *
+   * <p>This method is for Zeebe versions 8.5 through 8.7 (inclusive). Unlike
+   * {@link #createZeebeContainerBefore85}, it does not override exposed ports, as newer versions of
+   * the zeebe-testcontainers library already handle port exposure correctly.
+   *
+   * @param dockerImageName the docker image name of the Zeebe version to use
+   * @param tempDir the temporary directory to mount to /usr/local/zeebe/data
+   * @param logger the logger to use for the container logs
+   * @return the ZeebeContainer
+   */
+  public static ZeebeContainer createZeebeContainerBetween85And88(
+      final DockerImageName dockerImageName, final String tempDir, final Logger logger) {
+    return new ZeebeContainer(dockerImageName)
+        /* run the container with the current user, in order to access the data and delete it later */
+        .withCreateContainerCmdModifier(cmd -> cmd.withUser(TestUtils.getRunAsUser()))
+        // with 8.2 we disabled WAL per default
+        // we have to enabled it inorder to access the data from RocksDB
+        .withEnv("ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_DISABLEWAL", "false")
+        // Use loopback as the advertised host so Zeebe's internal cluster messaging can always
+        // resolve itself, regardless of how Testcontainers sets the container hostname.
+        .withEnv("ZEEBE_BROKER_NETWORK_ADVERTISEDHOST", "127.0.0.1")
+        .withLogConsumer(new Slf4jLogConsumer(logger))
+        .withFileSystemBind(tempDir, CONTAINER_PATH, BindMode.READ_WRITE);
   }
 
   /**
@@ -147,6 +181,9 @@ public final class TestUtils {
             // with 8.2 we disabled WAL per default
             // we have to enabled it inorder to access the data from RocksDB
             .withEnv("ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_DISABLEWAL", "false")
+            // Use loopback as the advertised host so Zeebe's internal cluster messaging can always
+            // resolve itself, regardless of how Testcontainers sets the container hostname.
+            .withEnv("ZEEBE_BROKER_NETWORK_ADVERTISEDHOST", "127.0.0.1")
             // with 8.8 we have the OC with all component together
             // to run Zeebe only we need to disable the secondary storage
             // and set the active profiles to broker only

--- a/backend/src/test/kotlin/io/zell/zdb/v88/SnapshotGeneratorV88Test.java
+++ b/backend/src/test/kotlin/io/zell/zdb/v88/SnapshotGeneratorV88Test.java
@@ -15,127 +15,39 @@
  */
 package io.zell.zdb.v88;
 
-import static io.zell.zdb.TestUtils.createZeebeContainerGreaterOrEquals88;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.zeebe.containers.ZeebeContainer;
-import io.zell.zdb.SnapshotFixture;
-import io.zell.zdb.SnapshotMetadata;
+import io.zell.zdb.SnapshotGeneratorSupport;
 import io.zell.zdb.TestUtils;
-import io.zell.zdb.ZeebeContentCreator;
-import io.zell.zdb.ZeebePaths;
-import io.zell.zdb.state.incident.IncidentState;
-import java.io.File;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.utility.DockerImageName;
 
 @Tag("snapshot-generator")
 class SnapshotGeneratorV88Test {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SnapshotGeneratorV88Test.class);
-  private static final DockerImageName DOCKER_IMAGE =
-      DockerImageName.parse("camunda/camunda:8.8.0");
-  private static final File TEMP_DIR = TestUtils.newTmpFolder(SnapshotGeneratorV88Test.class);
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-  // Relative to backend/ module root — Maven sets CWD to the module during tests
-  private static final Path SNAPSHOT_TARGET = Path.of("src/test/resources/zeebe-states/v8.8");
-  private static final Path SNAPSHOT_ZIP =
-      Path.of("src/test/resources/zeebe-states/v8.8.zip");
-
-  private static final BpmnModelInstance PROCESS =
-      Bpmn.createExecutableProcess("process")
-          .startEvent()
-          .parallelGateway("gw")
-          .serviceTask("task")
-          .zeebeJobType("type")
-          .endEvent()
-          .moveToLastGateway()
-          .serviceTask("incidentTask")
-          .zeebeInputExpression("=foo", "bar")
-          .zeebeJobType("incidentTask")
-          .zeebeJobRetriesExpression("=foo")
-          .endEvent()
-          .done();
-
-  private static final ZeebeContentCreator zeebeContentCreator =
-      new ZeebeContentCreator(PROCESS);
-  private static ZeebeContainer zeebeContainer;
-
-  static {
-    TEMP_DIR.mkdirs();
-  }
+  private static SnapshotGeneratorSupport.GeneratorContext context;
 
   @BeforeAll
   static void startContainerAndCreateContent() {
-    zeebeContainer =
-        createZeebeContainerGreaterOrEquals88(DOCKER_IMAGE, TEMP_DIR.getPath(), LOGGER);
-    zeebeContainer.start();
-    zeebeContentCreator.createContent(zeebeContainer.getExternalGatewayAddress());
+    context =
+        SnapshotGeneratorSupport.startContainerAndCreateContent(
+            SnapshotGeneratorV88Test.class,
+            "camunda/camunda:8.8.0",
+            TestUtils::createZeebeContainerGreaterOrEquals88,
+            LOGGER);
   }
 
   @AfterAll
   static void stopContainerAndCleanup() throws Exception {
-    if (zeebeContainer != null && zeebeContainer.isRunning()) {
-      zeebeContainer.stop();
-    }
-    SnapshotFixture.deleteRecursively(TEMP_DIR.toPath());
+    SnapshotGeneratorSupport.stopContainerAndCleanup(context);
   }
 
   @Test
   void generateSnapshot() throws Exception {
-    // given: content created in @BeforeAll, stop container to flush all data to disk
-    zeebeContainer.stop();
-
-    // when: copy Zeebe data directory to committed test resources
-    SnapshotFixture.deleteRecursively(SNAPSHOT_TARGET);
-    SnapshotFixture.copyDirectory(TEMP_DIR.toPath(), SNAPSHOT_TARGET);
-
-    // Query the incident key from the committed snapshot (not available directly from
-    // ZeebeContentCreator — we derive it by reading ZDB state on the copied snapshot)
-    final var runtimePath =
-        ZeebePaths.Companion.getRuntimePath(SNAPSHOT_TARGET.toFile(), "1");
-    final var incidentKeys = new ArrayList<Long>();
-    new IncidentState(runtimePath)
-        .listIncidents(
-            json -> {
-              try {
-                incidentKeys.add(OBJECT_MAPPER.readTree(json).get("key").asLong());
-              } catch (Exception e) {
-                throw new RuntimeException(e);
-              }
-            });
-    Assertions.assertThat(incidentKeys)
-        .as("expected exactly one incident in the snapshot")
-        .hasSize(1);
-
-    // then: write metadata.json with all keys needed by Version88GoldenTest
-    final var metadata =
-        new SnapshotMetadata(
-            zeebeContentCreator.firstProcessKey,
-            zeebeContentCreator.secondProcessKey,
-            zeebeContentCreator.processInstanceEvent.getProcessInstanceKey(),
-            zeebeContentCreator.elementInstanceKey,
-            zeebeContentCreator.responseJobKey,
-            incidentKeys.get(0));
-
-    OBJECT_MAPPER
-        .writerWithDefaultPrettyPrinter()
-        .writeValue(SNAPSHOT_TARGET.resolve("metadata.json").toFile(), metadata);
-
-    // Zip relative to src/test/resources so entries carry the zeebe-states/v8.8/ prefix,
-    // matching the path the golden test resolves after unzipping (snapshotDir = tempRoot.resolve("zeebe-states/v8.8"))
-    SnapshotFixture.pack(SNAPSHOT_TARGET, SNAPSHOT_ZIP);
-    SnapshotFixture.deleteRecursively(SNAPSHOT_TARGET);
+    // given/when/then
+    SnapshotGeneratorSupport.generateSnapshot(context, "v8.8");
   }
 }


### PR DESCRIPTION
## What

- Extracts shared snapshot generator plumbing into SnapshotGeneratorSupport.
- Keeps SnapshotGeneratorV88Test as a small version-specific wrapper.
- Adds shared Zeebe container helper setup for future v8.5-v8.7 snapshot generators.
- Updates snapshot generator docs to use the current surefire.excludedGroups override.

## Why

The v8.1-v8.7 migration PRs otherwise duplicate the same generator logic and repeatedly conflict on shared test infrastructure. This is the base PR for the stack.

## Stack

Base for #684, then #685, #686, #687, #688, #689, and #690. Duplicate aggregate PR #674 and older v8.1 PR #683 were closed.

## Validation

- git diff --check
- GitHub Actions running on this PR
- Local Maven validation was blocked by the runtime permission policy.